### PR TITLE
Fix S3 CloudFront 403 response on refresh

### DIFF
--- a/infra/aws-cloudfront-functions/url-rewrite/test-events/about-me-filename.json
+++ b/infra/aws-cloudfront-functions/url-rewrite/test-events/about-me-filename.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "0.0.0.0"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/about-me/index.html",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/aws-cloudfront-functions/url-rewrite/test-events/about-me-no-filename-1.json
+++ b/infra/aws-cloudfront-functions/url-rewrite/test-events/about-me-no-filename-1.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "0.0.0.0"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/about-me/",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/aws-cloudfront-functions/url-rewrite/test-events/about-me-no-filename-2.json
+++ b/infra/aws-cloudfront-functions/url-rewrite/test-events/about-me-no-filename-2.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "0.0.0.0"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/about-me",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/aws-cloudfront-functions/url-rewrite/test-events/root-filename.json
+++ b/infra/aws-cloudfront-functions/url-rewrite/test-events/root-filename.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "0.0.0.0"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/index.html",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/aws-cloudfront-functions/url-rewrite/test-events/root-no-filename.json
+++ b/infra/aws-cloudfront-functions/url-rewrite/test-events/root-no-filename.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "0.0.0.0"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}

--- a/infra/aws-cloudfront-functions/url-rewrite/url-rewrite.js
+++ b/infra/aws-cloudfront-functions/url-rewrite/url-rewrite.js
@@ -1,0 +1,12 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    if (uri.endsWith('/') === true) {
+        request.uri += 'index.html';
+    } else if (uri.includes('.') !== true) {
+        request.uri += '/index.html';
+    }
+
+    return request;
+}


### PR DESCRIPTION
## Issue
When a user visits a page on the site other than the landing page and refreshes it manually, they get an error. See the below screenshot.

![image](https://user-images.githubusercontent.com/1107282/236565201-2d9521fc-7752-4a76-9158-607986441efc.png)

In AWS CloudFront we can [only define a default root object](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DefaultRootObject.html). This means:

> However, if you define a default root object, an end-user request for a subdirectory of your distribution does not return the default root object. For example, suppose index.html is your default root object and that CloudFront receives an end-user request for the install directory under your CloudFront distribution:
>
> https://d111111abcdef8.cloudfront.net/install/
>
> CloudFront does not return the default root object even if a copy of index.html appears in the install directory.

## Solution
We need to create an AWS CloudFront Function to rewrite the URL and add `index.html` to request URLs that don’t have a file name. More info [here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-index.html).

## Tasks
- [x] Create an AWS CloudFront Function to rewrite the URL
- [x] Add test events
