### PR TITLE
Improve security by adding HTTP headers

### DIFF
--- a/infra/aws-cloudfront-functions/security-headers/security-headers.js
+++ b/infra/aws-cloudfront-functions/security-headers/security-headers.js
@@ -1,0 +1,18 @@
+function handler(event) {
+    var response = event.response;
+    var headers = response.headers;
+
+    headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload' };
+    headers['content-security-policy'] = {
+        value: "default-src 'none'; connect-src 'self'; manifest-src 'self'; img-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'"
+    };
+    headers['x-content-type-options'] = { value: 'nosniff' };
+    headers['x-frame-options'] = { value: 'DENY' };
+    headers['x-xss-protection'] = { value: '1; mode=block' };
+    headers['referrer-policy'] = { value: 'same-origin' };
+    headers['permissions-policy'] = {
+        value: 'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()'
+    };
+
+    return response;
+}

--- a/infra/aws-cloudfront-functions/security-headers/test-events/response.json
+++ b/infra/aws-cloudfront-functions/security-headers/test-events/response.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-response"
+    },
+    "viewer": {
+        "ip": "0.0.0.0"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/index.html",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    },
+    "response": {
+        "statusCode": 200,
+        "statusDescription": "OK",
+        "headers": {},
+        "cookies": {}
+    }
+}


### PR DESCRIPTION
Refs #7

## Tasks
- Add the following HTTP headers via a CloudFront Function:
  - [x] `strict-transport-security`
  - [x] `content-security-policy`
  - [x] `x-content-type-options`
  - [x] `x-frame-options`
  - [x] `x-xss-protection`
  - [x] `referrer-policy`
  - [x] `permissions-policy`
- [x] Add test events
