### PR TITLE
Add Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Dependency directories
+node_modules/
+
+# Cache folder
+.cache/
+
+# Build output
+src/gatsby-types.d.ts
+
+# Coverage directory used by tools like istanbul
+reports
+coverage
+*.lcov
+
+# MacOS
+.DS_Store
+
+# Dotenv
+.env

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ indent_size = 4
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx
+LABEL maintainer="Tamas Mezei <tamas.mezei@brokenrobot.xyz>"
+
+COPY ./public /website
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env make
 
-.PHONY: build_website build_container run_container
+.PHONY: build_website build_container run_container stop_container
 
 build_website:
 	npm run clean && npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+#!/usr/bin/env make
+
+.PHONY: build_website build_container run_container
+
+build_website:
+	npm run clean && npm run build
+
+build_container: build_website
+	docker build -t brokenrobot.xyz .
+
+run_container: build_container
+	docker run -p 8080:80 -d --name brokenrobot.xyz --rm brokenrobot.xyz
+
+stop_container:
+	docker stop brokenrobot.xyz

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,5 +14,40 @@ http {
         location / {
             try_files $uri $uri/ =404;
         }
+
+        add_header X-Frame-Options "DENY";
+        add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+        add_header X-XSS-Protection "1; mode=block";
+        add_header Content-Security-Policy "default-src 'none'; connect-src 'self'; manifest-src 'self'; img-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'" always;
+        add_header Referrer-Policy "same-origin";
+        add_header X-Content-Type-Options "nosniff";
+        add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()";
+
+        gzip on;
+        gzip_comp_level 4;
+        gzip_http_version 1.1;
+        gzip_min_length 1024;
+        gzip_proxied any;
+        gzip_types
+            application/atom+xml
+            application/geo+json
+            application/javascript
+            application/x-javascript
+            application/json
+            application/ld+json
+            application/manifest+json
+            application/rdf+xml
+            application/rss+xml
+            application/xhtml+xml
+            application/xml
+            font/eot
+            font/otf
+            font/ttf
+            image/svg+xml
+            text/css
+            text/javascript
+            text/plain
+            text/xml;
+        gzip_vary off;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+events {
+    worker_connections  1024;
+}
+
+http {
+    add_header Cache-Control max-age=0,no-cache,no-store,must-revalidate;
+    include mime.types;
+    server {
+        listen      80;
+        server_name localhost;
+        root        /website;
+        index       index.html;
+        error_page 404 /404.html;
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}


### PR DESCRIPTION
Make the static website capable to run in a docker container using `nginx`. It opens up the possibility to host the website in a different way, however for now the main goal is to run it locally for testing purposes.

The implementation is not optimized for production, however it adds the same security headers and compression as AWS CloudFront.

## Tasks
- [x] Add `Dockerfile`
- [x] Add `nginx.conf`
- [x] Add `Makefile`
- [x] Update `.editorconfig`
