### PR TITLE
Add BrokenRobot related posts to about page

### DIFF
--- a/content/posts/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/index.md
+++ b/content/posts/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/index.md
@@ -10,6 +10,7 @@ tags:
     - certificatemanager
     - staticwebsite
     - hosting
+    - brokenrobot
 ---
 
 Today we will dive deep into the world of hosting a static website on Amazon S3 using CloudFront. If you're looking for a secure, reliable, scalable, cost effective and performant solution, you've come to the right place.

--- a/content/posts/hosting-a-static-website-on-amazon-s3/index.md
+++ b/content/posts/hosting-a-static-website-on-amazon-s3/index.md
@@ -8,6 +8,7 @@ tags:
     - route53
     - staticwebsite
     - hosting
+    - brokenrobot
 ---
 
 Hosting a simple static website on Amazon Web Services (AWS) can be daunting at first, but luckily it's quite straightforward. One option for hosting a static website on AWS is to use Amazon S3.

--- a/content/posts/url-redirect-with-amazon-cloudfront-and-amazon-route-53/index.md
+++ b/content/posts/url-redirect-with-amazon-cloudfront-and-amazon-route-53/index.md
@@ -11,6 +11,7 @@ tags:
     - certificatemanager
     - staticwebsite
     - hosting
+    - brokenrobot
 ---
 
 In this blog post we will discover how to implement a consitent, SEO friendly URL structure, focusing on using the **www** subdomain over the apex domain, for a personal website, using URL redirection with Amazon CloudFront and Route 53.

--- a/src/components/blog-posts/__snapshots__/blog-post-list-item.test.tsx.snap
+++ b/src/components/blog-posts/__snapshots__/blog-post-list-item.test.tsx.snap
@@ -6,11 +6,15 @@ exports[`<BlogPostListItem /> should render with h2 heading 1`] = `
 >
   <header>
     <h2>
-      <a
-        href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+      <span
+        className="hover:underline"
       >
-        Advanced static website hosting with Amazon S3 and CloudFront
-      </a>
+        <a
+          href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+        >
+          Advanced static website hosting with Amazon S3 and CloudFront
+        </a>
+      </span>
     </h2>
     <time
       dateTime="2023-05-29T18:00:00.000Z"
@@ -30,11 +34,15 @@ exports[`<BlogPostListItem /> should render with h3 heading 1`] = `
 >
   <header>
     <h3>
-      <a
-        href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+      <span
+        className="hover:underline"
       >
-        Advanced static website hosting with Amazon S3 and CloudFront
-      </a>
+        <a
+          href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+        >
+          Advanced static website hosting with Amazon S3 and CloudFront
+        </a>
+      </span>
     </h3>
     <time
       dateTime="2023-05-29T18:00:00.000Z"

--- a/src/components/blog-posts/__snapshots__/blog-post-list.test.tsx.snap
+++ b/src/components/blog-posts/__snapshots__/blog-post-list.test.tsx.snap
@@ -7,11 +7,15 @@ exports[`<BlogPostList /> should render with h2 heading 1`] = `
   >
     <header>
       <h2>
-        <a
-          href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+        <span
+          className="hover:underline"
         >
-          Advanced static website hosting with Amazon S3 and CloudFront
-        </a>
+          <a
+            href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+          >
+            Advanced static website hosting with Amazon S3 and CloudFront
+          </a>
+        </span>
       </h2>
       <time
         dateTime="2023-05-29T18:00:00.000Z"
@@ -28,11 +32,15 @@ exports[`<BlogPostList /> should render with h2 heading 1`] = `
   >
     <header>
       <h2>
-        <a
-          href="/blog/hosting-a-static-website-on-amazon-s3/"
+        <span
+          className="hover:underline"
         >
-          Hosting a static website on Amazon S3
-        </a>
+          <a
+            href="/blog/hosting-a-static-website-on-amazon-s3/"
+          >
+            Hosting a static website on Amazon S3
+          </a>
+        </span>
       </h2>
       <time
         dateTime="2023-05-04T17:58:32.000Z"
@@ -49,11 +57,15 @@ exports[`<BlogPostList /> should render with h2 heading 1`] = `
   >
     <header>
       <h2>
-        <a
-          href="/blog/hello-world/"
+        <span
+          className="hover:underline"
         >
-          Hello, World!
-        </a>
+          <a
+            href="/blog/hello-world/"
+          >
+            Hello, World!
+          </a>
+        </span>
       </h2>
       <time
         dateTime="2023-05-01T10:10:05.000Z"
@@ -75,11 +87,15 @@ exports[`<BlogPostList /> should render with h3 heading 1`] = `
   >
     <header>
       <h3>
-        <a
-          href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+        <span
+          className="hover:underline"
         >
-          Advanced static website hosting with Amazon S3 and CloudFront
-        </a>
+          <a
+            href="/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/"
+          >
+            Advanced static website hosting with Amazon S3 and CloudFront
+          </a>
+        </span>
       </h3>
       <time
         dateTime="2023-05-29T18:00:00.000Z"
@@ -96,11 +112,15 @@ exports[`<BlogPostList /> should render with h3 heading 1`] = `
   >
     <header>
       <h3>
-        <a
-          href="/blog/hosting-a-static-website-on-amazon-s3/"
+        <span
+          className="hover:underline"
         >
-          Hosting a static website on Amazon S3
-        </a>
+          <a
+            href="/blog/hosting-a-static-website-on-amazon-s3/"
+          >
+            Hosting a static website on Amazon S3
+          </a>
+        </span>
       </h3>
       <time
         dateTime="2023-05-04T17:58:32.000Z"
@@ -117,11 +137,15 @@ exports[`<BlogPostList /> should render with h3 heading 1`] = `
   >
     <header>
       <h3>
-        <a
-          href="/blog/hello-world/"
+        <span
+          className="hover:underline"
         >
-          Hello, World!
-        </a>
+          <a
+            href="/blog/hello-world/"
+          >
+            Hello, World!
+          </a>
+        </span>
       </h3>
       <time
         dateTime="2023-05-01T10:10:05.000Z"

--- a/src/components/blog-posts/blog-post-list-item.tsx
+++ b/src/components/blog-posts/blog-post-list-item.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { FunctionComponent, ReactElement } from 'react';
 
-import { Link } from 'gatsby';
+import { InternalLink } from '../internal-link/internal-link';
 
 type BlogPostListItemProps = {
     title: string;
@@ -27,7 +27,7 @@ const BlogPostListItem: FunctionComponent<BlogPostListItemProps> = ({
         >
             <header>
                 <HeadingType>
-                    <Link to={`/blog/${slug}/`}>{title}</Link>
+                    <InternalLink to={`/blog/${slug}/`}>{title}</InternalLink>
                 </HeadingType>
 
                 <time dateTime={published}>{publishedFormatted}</time>

--- a/src/components/blog-posts/use-brokenrobot-related-blog-posts.tsx
+++ b/src/components/blog-posts/use-brokenrobot-related-blog-posts.tsx
@@ -1,0 +1,29 @@
+import { graphql, useStaticQuery } from 'gatsby';
+
+import type { BlogPosts } from './blog-posts.types';
+
+const useBrokenRobotRelatedBlogPosts = (): BlogPosts => {
+    const {
+        allMarkdownRemark: { nodes: blogPosts }
+    } = useStaticQuery(graphql`
+        query GetBrokenRobotRelatedBlogPosts {
+            allMarkdownRemark(
+                filter: { frontmatter: { tags: { eq: "brokenrobot" } } }
+                sort: { frontmatter: { published: ASC } }
+            ) {
+                nodes {
+                    excerpt(pruneLength: 250)
+                    frontmatter {
+                        title
+                        published
+                        slug
+                    }
+                }
+            }
+        }
+    `);
+
+    return blogPosts;
+};
+
+export { useBrokenRobotRelatedBlogPosts };

--- a/src/pages/about-me/index.tsx
+++ b/src/pages/about-me/index.tsx
@@ -4,12 +4,15 @@ import type { FunctionComponent, ReactElement } from 'react';
 import type { HeadFC } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
 
+import { useBrokenRobotRelatedBlogPosts } from '../../components/blog-posts/use-brokenrobot-related-blog-posts';
 import { ExternalLink } from '../../components/external-link/external-link';
 import { InternalLink } from '../../components/internal-link/internal-link';
 import { Layout } from '../../components/layout/layout';
 import { SeoWebPage } from '../../components/seo/seo-web-page';
 
 const AboutMePage: FunctionComponent = (): ReactElement => {
+    const blogPosts = useBrokenRobotRelatedBlogPosts();
+
     return (
         <Layout>
             <section>
@@ -81,17 +84,25 @@ const AboutMePage: FunctionComponent = (): ReactElement => {
                 </p>
 
                 <p>
-                    I'll be documenting any improvements or modifications to the website through blog posts that will be
-                    published on this site.
-                </p>
-
-                <p>
                     The website's source code is available on{' '}
                     <ExternalLink href="https://github.com/mezeitamas/brokenrobot.xyz">GitHub</ExternalLink>. Please
                     don't hesitate to create an{' '}
                     <ExternalLink href="https://github.com/mezeitamas/brokenrobot.xyz/issues">issue</ExternalLink> if
                     you encounter a bug or typo, or if you have any suggestions to offer.
                 </p>
+
+                <p>
+                    I'll be documenting any improvements or modifications to the website through blog posts that will be
+                    published on this site:
+                </p>
+
+                <ul>
+                    {blogPosts.map(({ frontmatter: { title, slug } }) => (
+                        <li key={slug}>
+                            <InternalLink to={`/blog/${slug}/`}>{title}</InternalLink>
+                        </li>
+                    ))}
+                </ul>
             </section>
         </Layout>
     );

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -80,6 +80,14 @@ test.describe('Post: Hosting a static website on Amazon S3', () => {
         await page.getByRole('heading').getByRole('link', { name: 'Hosting a static website on Amazon S3' }).click();
         await expect(page).toHaveTitle(/Hosting a static website on Amazon S3/);
     });
+
+    test('should be accessible from the about page', async ({ page }) => {
+        await page.goto('./about-me');
+        await expect(page).toHaveTitle(/About me/);
+
+        await page.getByRole('link', { name: 'Hosting a static website on Amazon S3' }).click();
+        await expect(page).toHaveTitle(/Hosting a static website on Amazon S3/);
+    });
 });
 
 test.describe('Post: Advanced static website hosting with Amazon S3 and CloudFront', () => {
@@ -104,6 +112,14 @@ test.describe('Post: Advanced static website hosting with Amazon S3 and CloudFro
             .click();
         await expect(page).toHaveTitle(/Advanced static website hosting with Amazon S3 and CloudFront/);
     });
+
+    test('should be accessible from the about page', async ({ page }) => {
+        await page.goto('./about-me');
+        await expect(page).toHaveTitle(/About me/);
+
+        await page.getByRole('link', { name: 'Advanced static website hosting with Amazon S3 and CloudFront' }).click();
+        await expect(page).toHaveTitle(/Advanced static website hosting with Amazon S3 and CloudFront/);
+    });
 });
 
 test.describe('Post: URL redirect with Amazon CloudFront and Amazon Route 53', () => {
@@ -126,6 +142,14 @@ test.describe('Post: URL redirect with Amazon CloudFront and Amazon Route 53', (
             .getByRole('heading')
             .getByRole('link', { name: 'URL redirect with Amazon CloudFront and Amazon Route 53' })
             .click();
+        await expect(page).toHaveTitle(/URL redirect with Amazon CloudFront and Amazon Route 53/);
+    });
+
+    test('should be accessible from the about page', async ({ page }) => {
+        await page.goto('./about-me');
+        await expect(page).toHaveTitle(/About me/);
+
+        await page.getByRole('link', { name: 'URL redirect with Amazon CloudFront and Amazon Route 53' }).click();
         await expect(page).toHaveTitle(/URL redirect with Amazon CloudFront and Amazon Route 53/);
     });
 });


### PR DESCRIPTION
Add the website related blog posts to the about page, so viewers can have an overview and see the whole journey.

## Tasks
- [x] Add BrokenRobot related posts to about page
- [x] Update all blog post `tags`
- [x] Replace Gatsby `Link` with `InternalLink`
- [x] Add tests
- [x] Update snapshot tests
