### PR TITLE
Optimize the CI pipeline

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
         },
         "ghcr.io/devcontainers/features/terraform:1": {}
     },
-    "postCreateCommand": "npm install",
+    "postCreateCommand": "npm install && npm run install:playwright",
     "customizations": {
         "vscode": {
             "settings": {},

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: dist
+          path: dist/
 
       - name: ls
         run: ls -al

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -84,17 +84,11 @@ jobs:
           node-version-file: '.node-version'
           cache: 'npm'
 
-      - name: ls
-        run: ls -al
-
       - name: Download dist
         uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/
-
-      - name: ls
-        run: ls -al
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -84,10 +84,16 @@ jobs:
           node-version-file: '.node-version'
           cache: 'npm'
 
+      - name: ls
+        run: ls -al
+
       - name: Download dist
         uses: actions/download-artifact@v3
         with:
           name: dist
+
+      - name: ls
+        run: ls -al
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -61,9 +61,17 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Upload dist
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+          retention-days: 3
+
   test:
     name: 'Test'
     runs-on: ubuntu-latest
+    needs: build
     timeout-minutes: 10
 
     steps:
@@ -76,11 +84,16 @@ jobs:
           node-version-file: '.node-version'
           cache: 'npm'
 
+      - name: Download dist
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+
       - name: Install dependencies
         run: npm ci
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npm run install:playwright
 
       - name: E2E test check
         run: npm run test:e2e:check
@@ -91,4 +104,4 @@ jobs:
         with:
           name: e2e-test-reports
           path: reports/tests/e2e/
-          retention-days: 1
+          retention-days: 3

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "type": "module",
     "scripts": {
-        "postinstall": "playwright install --with-deps",
+        "install:playwright": "playwright install --with-deps",
         "clean": "rimraf dist/ reports/ .astro/ .cache/ test-results/ playwright-report/",
         "format:check": "prettier '**/*.{astro,js,jsx,ts,tsx,cjs,mjs,json,md,mdx,yml}' --check",
         "format:fix": "prettier '**/*.{astro,js,jsx,ts,tsx,cjs,mjs,json,md,mdx,yml}' --write",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
     ],
     webServer: {
         command: 'npm run serve',
-        timeout: 120_000,
+        timeout: 240_000,
         url: `http://localhost:${process.env.BROKENROBOT_PORT}`,
         reuseExistingServer: process.env.CI === undefined
     }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,8 +40,8 @@ export default defineConfig({
         }
     ],
     webServer: {
-        command: 'npm run build && npm run serve',
-        timeout: 420_000,
+        command: 'npm run serve',
+        timeout: 120_000,
         url: `http://localhost:${process.env.BROKENROBOT_PORT}`,
         reuseExistingServer: process.env.CI === undefined
     }


### PR DESCRIPTION
The previous pipeline built twice the dist which is a waste of resources. This MR is giving a solution to this.

## Tasks
- [x] Upload the `dist/` folder in the `Build` job
- [x] Download the `dist/` folder and reuse it in the `Test` job
- [x] Only install `Playwright` dependencies in the `Test` job
