### PR TITLE
Add Cache-Control headers

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     server: {
         port: process.env.BROKENROBOT_PORT === undefined ? 4321 : parseInt(process.env.BROKENROBOT_PORT, 10),
         headers: {
+            'Cache-Control': `public, max-age=0, must-revalidate`,
             'Content-Security-Policy': `default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self' 'unsafe-inline'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'self'; script-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';`,
             'Permissions-Policy': `accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()`,
             'Referrer-Policy': `same-origin`,

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -188,6 +188,13 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
 
   custom_headers_config {
     items {
+      header = "Cache-Control"
+      value  = "public, max-age=0, must-revalidate"
+
+      override = true
+    }
+
+    items {
       header = "permissions-policy"
       value  = "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()"
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,7 +27,7 @@ http {
             try_files $uri $uri/ =404;
         }
 
-        add_header Cache-Control "max-age=0,no-cache,no-store,must-revalidate";
+        add_header Cache-Control "public, max-age=0, must-revalidate";
         add_header X-Frame-Options "DENY";
         add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
         add_header Content-Security-Policy "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self' 'unsafe-inline'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'self'; script-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';" always;


### PR DESCRIPTION
## Tasks
- [x] Set the `Cache-Control` HTTP header to `public, max-age=0, must-revalidate`

## Notes
`public, max-age=0, must-revalidate` means that the response can be stored by any cache, but it must check with the server for a fresh copy every time before serving it, even if the server is down or can't be reached.