### PR TITLE
Add deployment pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -133,7 +133,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy to AWS S3
-        run: aws s3 sync dist/ s3://${{ secrects.AWS_S3_BUCKET_NAME }} --delete
+        run: aws s3 sync dist/ s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete
 
       - name: Invalidate AWS CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -106,3 +106,34 @@ jobs:
           name: e2e-test-reports
           path: reports/tests/e2e/
           retention-days: 3
+
+  deploy:
+    name: 'Deploy'
+    runs-on: ubuntu-latest
+    needs: [verify, build, test]
+    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 10
+    environment: Production
+    concurrency:
+      group: Production
+      cancel-in-progress: true
+
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy to AWS S3
+        run: aws s3 sync dist/ s3://${{ secrects.AWS_S3_BUCKET_NAME }} --delete
+
+      - name: Invalidate AWS CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
This PR intends to add the `Deploy` job to the `pipeline.yml` which is responsible for deploying the website to AWS S3 and invalidating the AWS CloudFront cache. The deployment only happens on the `main` branch and only when the `Verify`, `Build` and `Test` jobs were successful.

## Tasks
- [x] Add the `Deploy` job to the already existing `pipeline.yml`
- [x] Add the `Production` environment to GitHub

## Notes
- Instead of long-lived GitHub secrets, it is better to use [`OIDC`](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)

## Useful links
- https://docs.github.com/en/actions
- https://github.com/aws-actions/configure-aws-credentials
- https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
