### PR TITLE
Fix CloudFront scripts

### DIFF
--- a/infra/aws/modules/simple-static-website/cloudfront-website/main.tf
+++ b/infra/aws/modules/simple-static-website/cloudfront-website/main.tf
@@ -10,7 +10,8 @@ resource "aws_cloudfront_distribution" "website" {
     origin_access_control_id = aws_cloudfront_origin_access_control.website.id
 
     origin_shield {
-      enabled = false
+      enabled              = false
+      origin_shield_region = "eu-central-1"
     }
   }
 


### PR DESCRIPTION
This PR intends to add the missing `origin_shield_region` to the `CloudFront` scripts.

## Tasks
- [x] Add the `origin_shield_region` property to the `CloudFront` scripts