### PR TITLE
Add an llms.txt index for language models

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+import { SITE_METADATA } from '../consts';
+
+// A Markdown map of the site for language models, following the llms.txt convention
+// (https://llmstxt.org): an H1 name, a blockquote summary, free prose, then sections of links.
+const SUMMARY =
+    'Personal website and blog of Tamas Mezei, a software engineer and architect in Zurich, Switzerland. Writing on software, engineering culture, coding conventions, and cloud infrastructure. No ads, no trackers.';
+
+export const GET: APIRoute = async ({ site }) => {
+    const toUrl = (path: string): string => new URL(path, site).href;
+
+    const posts = (await getCollection('blog')).sort(
+        (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
+    );
+
+    const body = [
+        `# ${SITE_METADATA.TITLE}`,
+        '',
+        `> ${SUMMARY}`,
+        '',
+        `Content is © ${SITE_METADATA.AUTHOR.NAME}, all rights reserved. Quote briefly with attribution and a link to the canonical URL.`,
+        '',
+        '## Pages',
+        '',
+        `- [Home](${toUrl('/')}): Latest posts and a short introduction.`,
+        `- [About](${toUrl('/about')}): Who Tamas is and what he works on.`,
+        `- [Blog](${toUrl('/blog')}): Every post, newest first.`,
+        '',
+        '## Blog posts',
+        '',
+        ...posts.map((post) => `- [${post.data.title}](${toUrl(`/blog/${post.id}`)}): ${post.data.excerpt}`),
+        '',
+        '## Optional',
+        '',
+        `- [RSS feed](${toUrl('/rss.xml')}): The same posts as a feed.`,
+        `- [Sitemap](${toUrl('/sitemap-index.xml')}): Every indexable URL on the site.`,
+        ''
+    ].join('\n');
+
+    return new Response(body, {
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+    });
+};


### PR DESCRIPTION
When someone points an LLM or agent at brokenrobot.xyz, it currently has to scrape HTML or infer structure from the sitemap. `llms.txt` gives it the site's own summary, the canonical pages, and every post with its excerpt - curation and prose that `sitemap-index.xml` and `rss.xml` can't carry.

Worth stating plainly: llms.txt is a *proposed* convention, not a standard, and no major crawler has committed to reading it. The realistic payoff is agents that are explicitly pointed at the domain, plus the attribution stance below - not traffic or ranking.

## What's in it

A single Astro endpoint, `src/pages/llms.txt.ts`, modelled on the existing `rss.xml.ts`. It emits:

- an H1 + blockquote summary of the site;
- a rights line: content is © Tamas Mezei, all rights reserved, quote briefly with attribution and a link to the canonical URL;
- **Pages** - home, about, blog;
- **Blog posts** - all posts, newest first, each with its excerpt;
- **Optional** - RSS feed and sitemap.

## Decisions worth reviewing

- **Generated, not static.** Built from `getCollection('blog')` rather than a hand-written `public/llms.txt`, so it can't fall behind published content. Site-level prose lives as constants in the endpoint; the H1 and author name reuse `SITE_METADATA`, so there's no second copy to drift.
- **All posts, newest first.** At 10 posts a cutoff would be premature. Revisit if the list ever gets unwieldy.
- **Scope stops at `llms.txt`.** No per-post `.md` variants and no `llms-full.txt` - those publish full article text as plain machine-readable copy, which sits awkwardly with the all-rights-reserved licence.
- **`robots.txt` untouched.** There's no standard directive for llms.txt; it would only be a comment line.
- **Scope `seo`** in the commit: this sits alongside the sitemap and `robots.txt` as a site-wide discovery artifact.
