### PR TITLE
Migrate the repository to the brokenrobot-xyz organization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,7 +60,7 @@
         "credentials": {
             "envVars": [
                 {
-                    "name": "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "name": "BROKEN_ROBOT_XYZ_GITHUB_PERSONAL_ACCESS_TOKEN",
                     "mode": "deny"
                 }
             ]

--- a/.mcp.json
+++ b/.mcp.json
@@ -27,7 +27,7 @@
                 "-i",
                 "--rm",
                 "-e",
-                "GITHUB_PERSONAL_ACCESS_TOKEN",
+                "GITHUB_PERSONAL_ACCESS_TOKEN=${BROKEN_ROBOT_XYZ_GITHUB_PERSONAL_ACCESS_TOKEN}",
                 "-e",
                 "GITHUB_READ_ONLY=1",
                 "-e",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the code repository for my personal website. The website is built with A
 
 To install and run the project, please follow these steps:
 
-- Clone the repository to your local machine using `git clone git@github.com:mezeitamas/brokenrobot.xyz.git`
+- Clone the repository to your local machine using `git clone git@github.com:brokenrobot-xyz/website.git`
 - Install dependencies by executing `npm install`
 - Start the development server by running `npm start`
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -33,8 +33,8 @@ With nvm the equivalent is `nvm install && nvm use`; asdf/volta read `.node-vers
 ## Install
 
 ```sh
-git clone git@github.com:mezeitamas/brokenrobot.xyz.git
-cd brokenrobot.xyz
+git clone git@github.com:brokenrobot-xyz/website.git
+cd website
 npm ci    # reproducible install from the committed package-lock.json
 npm start # dev server on http://localhost:4321
 ```

--- a/docs/tooling/workflow.md
+++ b/docs/tooling/workflow.md
@@ -163,10 +163,12 @@ Unlike the other servers, `github` needs a credential. Keep it read-only and out
   requests, Issues, Actions, Commit statuses. Nothing more — the server runs read-only and write actions
   are out of scope.
 - **Where it lives.** Put it in `.claude/settings.local.json` (gitignored), whose `env` block Claude Code
-  injects into the session — including the MCP Docker subprocess via `-e GITHUB_PERSONAL_ACCESS_TOKEN`:
+  injects into the session. The variable carries a `BROKEN_ROBOT_XYZ_` prefix so per-project tokens can
+  coexist (e.g. in the machine-global `~/.claude/settings.json`); `.mcp.json` maps it onto the
+  `GITHUB_PERSONAL_ACCESS_TOKEN` name the server's Docker container expects:
 
     ```json
-    { "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "github_pat_…" } }
+    { "env": { "BROKEN_ROBOT_XYZ_GITHUB_PERSONAL_ACCESS_TOKEN": "github_pat_…" } }
     ```
 
     Use this file — **not** `.zshrc` (a Dock/Finder launch of the desktop app doesn't source it) and **not**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "author": "Tamas Mezei",
     "repository": {
         "type": "git",
-        "url": "git@github.com:mezeitamas/brokenrobot.xyz.git"
+        "url": "git@github.com:brokenrobot-xyz/website.git"
     },
     "type": "module",
     "engines": {

--- a/src/content/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/index.mdx
+++ b/src/content/blog/advanced-static-website-hosting-with-amazon-s3-and-cloudfront/index.mdx
@@ -185,7 +185,7 @@ function handler(event) {
 }
 ```
 
-The source code can be also found on [GitHub](https://github.com/mezeitamas/brokenrobot.xyz/blob/v1.0.1/infra/aws-cloudfront-functions/url-rewrite/url-rewrite.js).
+The source code can be also found on [GitHub](https://github.com/brokenrobot-xyz/website/blob/v1.0.1/infra/aws-cloudfront-functions/url-rewrite/url-rewrite.js).
 
 #### Adding HTTP headers
 
@@ -216,7 +216,7 @@ function handler(event) {
 
 The discussion of these security headers falls beyond the scope of this post.
 
-The source code can be also found on [GitHub](https://github.com/mezeitamas/brokenrobot.xyz/blob/v1.2.0/infra/aws-cloudfront-functions/security-headers/security-headers.js).
+The source code can be also found on [GitHub](https://github.com/brokenrobot-xyz/website/blob/v1.2.0/infra/aws-cloudfront-functions/security-headers/security-headers.js).
 
 ## Implementation
 

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -96,11 +96,11 @@ const posts = (await getCollection('blog'))
 
             <p>
                 The website's source code is available on <ExternalLink
-                    href="https://github.com/mezeitamas/brokenrobot.xyz"
+                    href="https://github.com/brokenrobot-xyz/website"
                 >
                     GitHub
                 </ExternalLink>. Please don't hesitate to create an <ExternalLink
-                    href="https://github.com/mezeitamas/brokenrobot.xyz/issues"
+                    href="https://github.com/brokenrobot-xyz/website/issues"
                 >
                     issue
                 </ExternalLink>


### PR DESCRIPTION
The repository moved from `mezeitamas/brokenrobot.xyz` to the `brokenrobot-xyz` organization and was renamed to `website` — the org carries the brand, so repeating the domain in the repo name was redundant. This PR updates everything in the codebase that hardcoded the old owner/repo path, rather than relying on GitHub's redirects.

## Changes

- `package.json` — `repository.url` points at the new remote.
- `README.md` and `docs/development-environment.md` — clone commands use the new URL; the follow-up `cd` now matches the `website` directory the clone creates.
- `src/pages/about/index.astro` — the user-visible source-code and issue links.
- The S3/CloudFront blog article — the two tagged permalinks (`blob/v1.0.1`, `blob/v1.2.0`); tags transferred with the repo, so the new URLs resolve.
- The `github` MCP server token is renamed to `BROKEN_ROBOT_XYZ_GITHUB_PERSONAL_ACCESS_TOKEN` so per-project tokens can coexist in shared Claude Code settings: `.mcp.json` maps it onto the name the container expects, the sandbox credential deny follows the rename, and `docs/tooling/workflow.md` documents the new procedure.

## Deliberately untouched

- `src/consts.ts` — `github.com/mezeitamas` is the author profile link, not a repo link.
- `package.json` `name` — private and never published.
- `design-handoff/**` — historical artifact; its old URLs keep resolving via GitHub's redirects.
