### PR TITLE
Migrate hosting and DNS to Cloudflare

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -148,37 +148,6 @@ jobs:
           path: reports/tests/e2e/
           retention-days: 3
 
-  deploy-to-aws:
-    name: 'Deploy to AWS'
-    runs-on: ubuntu-24.04
-    needs: [verify, build, test]
-    if: github.ref == 'refs/heads/main'
-    timeout-minutes: 10
-    environment: Production
-    concurrency:
-      group: Production
-      cancel-in-progress: true
-
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v7
-        with:
-          name: dist
-          path: dist/
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Deploy to AWS S3
-        run: aws s3 sync dist/ s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete
-
-      - name: Invalidate AWS CloudFront cache
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
-
   deploy-to-cloudflare:
     name: 'Deploy to Cloudflare'
     runs-on: ubuntu-24.04

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -173,9 +173,10 @@ export default defineConfig({
         port: process.env.BROKENROBOT_PORT === undefined ? 4321 : parseInt(process.env.BROKENROBOT_PORT, 10),
         headers: {
             'Cache-Control': `public, max-age=0, must-revalidate`,
-            // Mirrors the edge header in nginx.conf so `astro preview` (and the Playwright suite,
-            // which runs against it) exercises the same two-layer policy as production. Keep the
-            // two in sync; the strict, hash-based half is the <meta> policy from `security.csp`.
+            // Mirrors the edge header in public/_headers (Cloudflare Pages — production) and
+            // nginx.conf so `astro preview` (and the Playwright suite, which runs against it)
+            // exercises the same two-layer policy as production. Keep the three in sync; the
+            // strict, hash-based half is the <meta> policy from `security.csp`.
             'Content-Security-Policy': `default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';`,
             'Permissions-Policy': `accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()`,
             'Referrer-Policy': `same-origin`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ src/
   utils/           readingTimePlugin.ts, codeBlockFocusPlugin.ts (Sätteri plugins)
   consts.ts        Centralized site metadata
   content.config.ts Content collection schema
-public/            Static assets (favicon, robots.txt)
+public/            Static assets (favicon, robots.txt, _headers)
 tests/             Playwright specs + visual snapshots
 infra/             Terraform (AWS, Cloudflare) + Kubernetes
 ```
@@ -143,8 +143,8 @@ each one.
    and styles and **no `unsafe-inline`**, so an injected inline script does not run. Because the
    hashes are per-page and follow the content, only the build can produce this layer — and
    because it lives in the HTML, it travels unchanged to any host.
-2. **An edge header**, defined in three places that must stay identical: the Terraform variable
-   `content_security_policy` (AWS CloudFront — production), `nginx.conf` (Kubernetes), and
+2. **An edge header**, defined in three places that must stay identical: `public/_headers`
+   (Cloudflare Pages — production), `nginx.conf` (Kubernetes), and
    `server.headers` in `astro.config.ts` (what `astro preview`, and therefore the Playwright
    suite, serves). This layer carries what a `<meta>` element cannot express —
    `frame-ancestors` — and additionally covers non-HTML responses and host-generated error

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -41,15 +41,15 @@ design overhaul.
 - **CI/CD** runs in GitHub Actions (`.github/workflows/pipeline.yml`): a `verify` →
   `build` → `test` sequence (format, lint, type-check, OpenSpec validation, then build, then
   Playwright), followed by deployment from `main`.
-- **Dual-cloud delivery:** the built site is published to both **AWS** (S3 sync + CloudFront
-  invalidation) and **Cloudflare Pages**, on every merge to `main`. The deploy jobs target the
-  `Production` and `Cloudflare` GitHub Environments; the release gate — a required approval on those
-  environments — is intended but **not yet configured** (see [development-workflow](development-workflow.md)).
+- **Delivery is Cloudflare Pages:** the built site is published to **Cloudflare Pages** on every
+  merge to `main`, with edge security headers from `public/_headers`. The deploy job targets the
+  `Cloudflare` GitHub Environment; the release gate — a required approval on that
+  environment — is intended but **not yet configured** (see [development-workflow](development-workflow.md)).
 
 ## Infrastructure & tooling
 
-- **Infrastructure as code:** Terraform under `infra/` (AWS, Cloudflare) plus Kubernetes
-  manifests. CI also runs `terraform fmt`/`validate`.
+- **Infrastructure as code:** Terraform under `infra/` (Cloudflare; the retired AWS stack
+  remains until it is destroyed) plus Kubernetes manifests. CI also runs `terraform fmt`/`validate`.
 - **Container:** a `Dockerfile` serves `dist/` via unprivileged Nginx.
 - **Dev container:** a reproducible environment with Node and Terraform pre-installed.
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -56,8 +56,8 @@ docs.
 
 - **Ad-free and tracking-free.** No ads, affiliate links, analytics spyware, or third-party
   trackers. This is core to the brand promise.
-- **Static by design.** A static-site model with dual-cloud delivery (AWS S3/CloudFront +
-  Cloudflare Pages). See [tech-stack](tech-stack.md).
+- **Static by design.** A static-site model delivered from Cloudflare Pages. See
+  [tech-stack](tech-stack.md).
 - **Strict security.** A strict CSP and hardened security headers. See
   [architecture](architecture.md) for what this means for theming.
 - **Stable URLs.** `/blog/<slug>/` permalinks and the RSS feed keep working — readers and

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -41,6 +41,37 @@ resource "aws_cloudfront_function" "viewer_request" {
 }
 
 # ########################################
+# Route 53 Domains - registration
+# ########################################
+# The Route 53 Domains API lives in us-east-1 only, hence the aliased
+# provider. Terraform adopts the already-registered domain rather than
+# registering it; destroying only forgets it. Adoption also enforces the
+# resource defaults: auto-renew on, WHOIS privacy on.
+#
+# Set cloudflare_name_servers (from the zone_name_servers output of
+# infra/cloudflare) to delegate DNS to Cloudflare; while it is empty the
+# registration keeps its current nameservers and stays out of Terraform.
+
+resource "aws_route53domains_registered_domain" "website" {
+  count = length(var.cloudflare_name_servers) > 0 ? 1 : 0
+
+  domain_name   = local.apex_domain_name
+  transfer_lock = var.domain_transfer_lock
+
+  dynamic "name_server" {
+    for_each = var.cloudflare_name_servers
+
+    content {
+      name = name_server.value
+    }
+  }
+
+  tags = local.tags
+
+  provider = aws.domain_registrar
+}
+
+# ########################################
 # SNS - alarms
 # ########################################
 

--- a/infra/aws/modules/simple-static-website/outputs.tf
+++ b/infra/aws/modules/simple-static-website/outputs.tf
@@ -3,3 +3,8 @@ output "cloudfront_website" {
     arn = module.cloudfront_website.arn
   }
 }
+
+output "route53_zone_name_servers" {
+  description = "Nameservers of the Route 53 hosted zone"
+  value       = module.route53_website.zone_name_servers
+}

--- a/infra/aws/modules/simple-static-website/route53-website/outputs.tf
+++ b/infra/aws/modules/simple-static-website/route53-website/outputs.tf
@@ -1,0 +1,4 @@
+output "zone_name_servers" {
+  description = "Nameservers of the Route 53 hosted zone"
+  value       = data.aws_route53_zone.website.name_servers
+}

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -1,1 +1,6 @@
 # Contains outputs from the resources created in main.tf
+
+output "route53_zone_name_servers" {
+  description = "Nameservers of the Route 53 hosted zone - the rollback values for cloudflare_name_servers during the DNS cutover"
+  value       = module.simple_static_website.route53_zone_name_servers
+}

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -4,3 +4,19 @@ variable "website_alarms_endpoints" {
   nullable    = false
   sensitive   = false
 }
+
+variable "cloudflare_name_servers" {
+  description = "Nameservers of the Cloudflare zone (the zone_name_servers output of infra/cloudflare); leave empty until the DNS cutover"
+  type        = list(string)
+  default     = []
+  nullable    = false
+  sensitive   = false
+}
+
+variable "domain_transfer_lock" {
+  description = "Whether the domain registration is locked against registrar transfer; disable to start the transfer to Cloudflare"
+  type        = bool
+  default     = true
+  nullable    = false
+  sensitive   = false
+}

--- a/infra/aws/versions.tf
+++ b/infra/aws/versions.tf
@@ -17,3 +17,8 @@ provider "aws" {
   region = "us-east-1"
   alias  = "certificate_authority"
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "domain_registrar"
+}

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,9 +1,9 @@
 # Cloudflare infrastructure
 
 Terraform for everything the site needs on Cloudflare: the DNS zone, the Pages project, its
-custom domains (`www` + apex), the proxied DNS records, and the edge redirect that 301s the
-apex to `www`. The edge security headers are not managed here — they ship with the build in
-`public/_headers`.
+custom domains (`www` + apex), the proxied DNS records, the edge redirect that 301s the apex
+to `www`, and — once the domain has transferred — the registrar settings. The edge security
+headers are not managed here; they ship with the build in `public/_headers`.
 
 ## Applying
 
@@ -16,27 +16,31 @@ terraform apply \
 ```
 
 The API token needs `Zone:Edit`, `DNS:Edit`, `Zone Rulesets:Edit`, and `Cloudflare Pages:Edit`.
-If the zone or Pages project already exists in the dashboard, import instead of recreating:
 
-```sh
-terraform import 'module.website.cloudflare_zone.website' '<zone_id>'
-terraform import 'module.website.cloudflare_pages_project.website' '<account_id>/brokenrobot-xyz'
-```
+## Migration runbook (AWS → Cloudflare)
 
-## Migration runbook (Route 53 → Cloudflare)
+Every step is a `terraform apply` except step 4, which no provider can perform. The Route 53
+zone holds nothing beyond the records `infra/aws` declares, so there is nothing to copy.
 
-One-time steps, in order. Terraform covers the website records only — any other records living
-in the Route 53 hosted zone (MX, TXT, verification records) must be recreated in the Cloudflare
-zone by hand before the nameserver switch.
-
-1. `terraform apply` — creates the zone (pending), records, custom domains, and redirect.
-2. Copy any non-website records from Route 53 into the Cloudflare zone.
-3. In the Route 53 **registered domains** console, set the nameservers to the
-   `zone_name_servers` output. The zone turns active once the registry updates.
-4. Verify `https://www.brokenrobot.xyz` serves from Pages (pretty URLs, the 404 page, the
-   security headers from `_headers`) and that the apex 301s to `www`.
-5. Transfer the registration: disable the transfer lock at Route 53, request the auth code,
-   and start the transfer under Cloudflare → Domain Registration. Approve AWS's confirmation
-   email to skip the waiting period.
-6. After a bake period, tear down `infra/aws` (`terraform destroy`; empty the S3 buckets
-   first) and delete the AWS deploy secrets and the `Production` environment from GitHub.
+1. **Create the Cloudflare side** — `terraform apply` here. The zone comes up pending; note
+   the `zone_name_servers` output.
+2. **Delegate DNS** — `terraform apply` in `infra/aws` with
+   `-var 'cloudflare_name_servers=["…", "…"]'` (the output from step 1). This adopts the
+   registered domain into Terraform and switches its nameservers to Cloudflare; the zone
+   turns active once the registry propagates. Adoption also enforces auto-renew and WHOIS
+   privacy on.
+3. **Verify** — `https://www.brokenrobot.xyz` serves from Pages (pretty URLs, the 404 page,
+   the `_headers` security headers) and the apex 301s to `www`. Roll back by re-applying
+   `infra/aws` with the nameserver variable empty.
+4. **Transfer the registration** — the one step outside Terraform. Unlock with
+   `-var domain_transfer_lock=false` on `infra/aws`, fetch the auth code
+   (`aws route53domains retrieve-domain-auth-code --domain-name brokenrobot.xyz --region us-east-1`),
+   start the transfer under Cloudflare → Domain Registration (one year's renewal at wholesale
+   is charged and added to the expiry), and approve the confirmation email AWS sends. ICANN
+   blocks transfers for 60 days after registration, a prior transfer, or a registrant contact
+   change.
+5. **Adopt the registrar settings** — once the transfer completes, `terraform apply` here
+   with `-var manage_registrar_domain=true`.
+6. **Tear down AWS** — after a bake period, `terraform destroy` in `infra/aws` (empty the S3
+   buckets first), then delete the AWS deploy secrets and the `Production` environment from
+   GitHub.

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,42 @@
+# Cloudflare infrastructure
+
+Terraform for everything the site needs on Cloudflare: the DNS zone, the Pages project, its
+custom domains (`www` + apex), the proxied DNS records, and the edge redirect that 301s the
+apex to `www`. The edge security headers are not managed here — they ship with the build in
+`public/_headers`.
+
+## Applying
+
+```sh
+terraform init
+terraform apply \
+    -var "cloudflare_api_token=…" \
+    -var "cloudflare_account_id=…" \
+    -var "apex_domain_name=brokenrobot.xyz"
+```
+
+The API token needs `Zone:Edit`, `DNS:Edit`, `Zone Rulesets:Edit`, and `Cloudflare Pages:Edit`.
+If the zone or Pages project already exists in the dashboard, import instead of recreating:
+
+```sh
+terraform import 'module.website.cloudflare_zone.website' '<zone_id>'
+terraform import 'module.website.cloudflare_pages_project.website' '<account_id>/brokenrobot-xyz'
+```
+
+## Migration runbook (Route 53 → Cloudflare)
+
+One-time steps, in order. Terraform covers the website records only — any other records living
+in the Route 53 hosted zone (MX, TXT, verification records) must be recreated in the Cloudflare
+zone by hand before the nameserver switch.
+
+1. `terraform apply` — creates the zone (pending), records, custom domains, and redirect.
+2. Copy any non-website records from Route 53 into the Cloudflare zone.
+3. In the Route 53 **registered domains** console, set the nameservers to the
+   `zone_name_servers` output. The zone turns active once the registry updates.
+4. Verify `https://www.brokenrobot.xyz` serves from Pages (pretty URLs, the 404 page, the
+   security headers from `_headers`) and that the apex 301s to `www`.
+5. Transfer the registration: disable the transfer lock at Route 53, request the auth code,
+   and start the transfer under Cloudflare → Domain Registration. Approve AWS's confirmation
+   email to skip the waiting period.
+6. After a bake period, tear down `infra/aws` (`terraform destroy`; empty the S3 buckets
+   first) and delete the AWS deploy secrets and the `Production` environment from GitHub.

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -7,40 +7,48 @@ headers are not managed here; they ship with the build in `public/_headers`.
 
 ## Applying
 
-```sh
-terraform init
-terraform apply \
-    -var "cloudflare_api_token=…" \
-    -var "cloudflare_account_id=…" \
-    -var "apex_domain_name=brokenrobot.xyz"
-```
+Both stacks run in Terraform Cloud, so applying means merging to `main` and letting the
+workspace run; variables are workspace variables, not CLI flags. The API token behind the
+workspace needs `Zone:Edit`, `DNS:Edit`, `Zone Rulesets:Edit`, and `Cloudflare Pages:Edit`.
 
-The API token needs `Zone:Edit`, `DNS:Edit`, `Zone Rulesets:Edit`, and `Cloudflare Pages:Edit`.
+| Workspace variable        | Default | Meaning                                                        |
+| ------------------------- | ------- | -------------------------------------------------------------- |
+| `cloudflare_api_token`    | —       | Cloudflare API token (sensitive)                               |
+| `cloudflare_account_id`   | —       | Cloudflare account (sensitive)                                 |
+| `apex_domain_name`        | —       | `brokenrobot.xyz`                                              |
+| `manage_registrar_domain` | `false` | Set once the registrar transfer has completed (runbook step 5) |
 
 ## Migration runbook (AWS → Cloudflare)
 
-Every step is a `terraform apply` except step 4, which no provider can perform. The Route 53
-zone holds nothing beyond the records `infra/aws` declares, so there is nothing to copy.
+Each phase is a Terraform Cloud run, driven by workspace variables; only step 4 happens
+outside Terraform. The Route 53 zone holds nothing beyond the records `infra/aws` declares,
+so there is nothing to copy.
 
-1. **Create the Cloudflare side** — `terraform apply` here. The zone comes up pending; note
-   the `zone_name_servers` output.
-2. **Delegate DNS** — `terraform apply` in `infra/aws` with
-   `-var 'cloudflare_name_servers=["…", "…"]'` (the output from step 1). This adopts the
+1. **Merge the migration change** — the merge lets Terraform Cloud apply this stack: the zone
+   comes up pending, and the Pages custom domains stay pending until DNS delegates. The
+   `infra/aws` workspace no-ops because `cloudflare_name_servers` defaults to empty. Note the
+   `zone_name_servers` output of this workspace and the `route53_zone_name_servers` output of
+   the AWS workspace (the rollback values). The merge also removes the AWS deploy job, so the
+   CloudFront copy stops receiving content — finish step 2 promptly.
+2. **Delegate DNS** — on the `infra/aws` workspace, set the `cloudflare_name_servers`
+   variable to the `zone_name_servers` output from step 1 and queue a run. This adopts the
    registered domain into Terraform and switches its nameservers to Cloudflare; the zone
    turns active once the registry propagates. Adoption also enforces auto-renew and WHOIS
    privacy on.
 3. **Verify** — `https://www.brokenrobot.xyz` serves from Pages (pretty URLs, the 404 page,
-   the `_headers` security headers) and the apex 301s to `www`. Roll back by re-applying
-   `infra/aws` with the nameserver variable empty.
-4. **Transfer the registration** — the one step outside Terraform. Unlock with
-   `-var domain_transfer_lock=false` on `infra/aws`, fetch the auth code
-   (`aws route53domains retrieve-domain-auth-code --domain-name brokenrobot.xyz --region us-east-1`),
+   the `_headers` security headers) and the apex 301s to `www`. To roll back, set
+   `cloudflare_name_servers` to the `route53_zone_name_servers` values and re-run — do not
+   empty the variable, which only forgets the domain resource and leaves the nameservers on
+   Cloudflare.
+4. **Transfer the registration** — the one step outside Terraform. Set
+   `domain_transfer_lock` to `false` on the `infra/aws` workspace and run, fetch the auth
+   code (`aws route53domains retrieve-domain-auth-code --domain-name brokenrobot.xyz --region us-east-1`),
    start the transfer under Cloudflare → Domain Registration (one year's renewal at wholesale
    is charged and added to the expiry), and approve the confirmation email AWS sends. ICANN
    blocks transfers for 60 days after registration, a prior transfer, or a registrant contact
    change.
-5. **Adopt the registrar settings** — once the transfer completes, `terraform apply` here
-   with `-var manage_registrar_domain=true`.
-6. **Tear down AWS** — after a bake period, `terraform destroy` in `infra/aws` (empty the S3
-   buckets first), then delete the AWS deploy secrets and the `Production` environment from
-   GitHub.
+5. **Adopt the registrar settings** — once the transfer completes, set
+   `manage_registrar_domain` to `true` on this workspace and queue a run.
+6. **Tear down AWS** — after a bake period, queue a destroy run on the `infra/aws` workspace
+   (empty the S3 buckets first), then delete the AWS deploy secrets and the `Production`
+   environment from GitHub, and remove `infra/aws` from the repository.

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -6,6 +6,7 @@ module "website" {
   source    = "./modules/simple-static-website"
   providers = { cloudflare = cloudflare }
 
-  cloudflare_account_id = var.cloudflare_account_id
-  apex_domain_name      = var.apex_domain_name
+  cloudflare_account_id   = var.cloudflare_account_id
+  apex_domain_name        = var.apex_domain_name
+  manage_registrar_domain = var.manage_registrar_domain
 }

--- a/infra/cloudflare/modules/simple-static-website/main.tf
+++ b/infra/cloudflare/modules/simple-static-website/main.tf
@@ -1,4 +1,18 @@
 ###############################################################################
+# Zone
+###############################################################################
+# The zone must be active (nameservers switched at the registrar) before the
+# Pages custom domains and the redirect rule below can serve traffic.
+
+resource "cloudflare_zone" "website" {
+  account = {
+    id = var.cloudflare_account_id
+  }
+  name = var.apex_domain_name
+  type = "full"
+}
+
+###############################################################################
 # Cloudflare Pages
 ###############################################################################
 
@@ -6,6 +20,74 @@ resource "cloudflare_pages_project" "website" {
   account_id        = var.cloudflare_account_id
   name              = replace(var.apex_domain_name, ".", "-")
   production_branch = "main"
+}
+
+resource "cloudflare_pages_domain" "www" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.website.name
+  name         = "www.${var.apex_domain_name}"
+}
+
+resource "cloudflare_pages_domain" "apex" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.website.name
+  name         = var.apex_domain_name
+}
+
+###############################################################################
+# DNS
+###############################################################################
+# Both records are proxied CNAMEs to the project's pages.dev hostname; the
+# apex CNAME is flattened by Cloudflare automatically.
+
+resource "cloudflare_dns_record" "www" {
+  zone_id = cloudflare_zone.website.id
+  name    = "www.${var.apex_domain_name}"
+  type    = "CNAME"
+  content = cloudflare_pages_project.website.subdomain
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "apex" {
+  zone_id = cloudflare_zone.website.id
+  name    = var.apex_domain_name
+  type    = "CNAME"
+  content = cloudflare_pages_project.website.subdomain
+  proxied = true
+  ttl     = 1
+}
+
+###############################################################################
+# Redirect - apex to www
+###############################################################################
+# Runs at the edge before the request reaches Pages, replacing the CloudFront
+# viewer-request function's apex redirect. The index.html rewrite that function
+# also did is native Pages behaviour and needs no rule.
+
+resource "cloudflare_ruleset" "redirect_apex_to_www" {
+  zone_id = cloudflare_zone.website.id
+  name    = "Redirect apex to www"
+  kind    = "zone"
+  phase   = "http_request_dynamic_redirect"
+
+  rules = [
+    {
+      ref         = "redirect_apex_to_www"
+      description = "301 apex requests to www, preserving path and query"
+      expression  = "(http.host eq \"${var.apex_domain_name}\")"
+      action      = "redirect"
+      action_parameters = {
+        from_value = {
+          status_code           = 301
+          preserve_query_string = true
+          target_url = {
+            expression = "concat(\"https://www.${var.apex_domain_name}\", http.request.uri.path)"
+          }
+        }
+      }
+    }
+  ]
 }
 
 ###############################################################################

--- a/infra/cloudflare/modules/simple-static-website/main.tf
+++ b/infra/cloudflare/modules/simple-static-website/main.tf
@@ -91,6 +91,22 @@ resource "cloudflare_ruleset" "redirect_apex_to_www" {
 }
 
 ###############################################################################
+# Registrar
+###############################################################################
+# Terraform cannot initiate the registrar transfer itself (auth code +
+# payment) - that single step happens in the dashboard. Once the domain is at
+# Cloudflare Registrar, set manage_registrar_domain to bring its settings
+# under Terraform.
+
+resource "cloudflare_registrar_domain" "website" {
+  count = var.manage_registrar_domain ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  domain_name = var.apex_domain_name
+  auto_renew  = true
+}
+
+###############################################################################
 # 404 Error Page
 ###############################################################################
 # Cloudflare Pages will automatically serve a public/404.html file as the custom error page for 404 errors.

--- a/infra/cloudflare/modules/simple-static-website/outputs.tf
+++ b/infra/cloudflare/modules/simple-static-website/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_name_servers" {
+  description = "Nameservers Cloudflare assigns to the zone; set these at the registrar"
+  value       = cloudflare_zone.website.name_servers
+}
+
+output "pages_subdomain" {
+  description = "The project's pages.dev hostname"
+  value       = cloudflare_pages_project.website.subdomain
+}

--- a/infra/cloudflare/modules/simple-static-website/variables.tf
+++ b/infra/cloudflare/modules/simple-static-website/variables.tf
@@ -9,3 +9,10 @@ variable "apex_domain_name" {
   type        = string
   sensitive   = false
 }
+
+variable "manage_registrar_domain" {
+  description = "Whether the domain is at Cloudflare Registrar (set after the transfer completes)"
+  type        = bool
+  default     = false
+  sensitive   = false
+}

--- a/infra/cloudflare/outputs.tf
+++ b/infra/cloudflare/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_name_servers" {
+  description = "Nameservers Cloudflare assigns to the zone; set these at the registrar"
+  value       = module.website.zone_name_servers
+}
+
+output "pages_subdomain" {
+  description = "The project's pages.dev hostname"
+  value       = module.website.pages_subdomain
+}

--- a/infra/cloudflare/variables.tf
+++ b/infra/cloudflare/variables.tf
@@ -15,3 +15,10 @@ variable "apex_domain_name" {
   type        = string
   sensitive   = false
 }
+
+variable "manage_registrar_domain" {
+  description = "Whether the domain is at Cloudflare Registrar (set after the transfer completes)"
+  type        = bool
+  default     = false
+  sensitive   = false
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,12 @@
+# Edge headers for Cloudflare Pages, applied to every response. This is the second of the two
+# Content-Security-Policy layers (the strict, hash-based half is the <meta> policy Astro emits
+# from `security.csp` in astro.config.ts). Keep these values identical to nginx.conf (Kubernetes)
+# and `server.headers` in astro.config.ts (what `astro preview` and the Playwright suite serve).
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Content-Security-Policy: default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+  Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()
+  Referrer-Policy: same-origin
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY


### PR DESCRIPTION
Moves the site fully to Cloudflare - hosting, DNS, and (after transfer) the domain registration - retiring the AWS S3/CloudFront serving path. The Cloudflare Pages deploy that already ran on every merge becomes the only delivery path.

## What changes

- **Terraform, Cloudflare** (`infra/cloudflare/`): now manages the DNS zone, the Pages custom domains (`www` + apex), proxied CNAMEs to the project's `pages.dev` hostname, and an edge Redirect Rule that 301s the apex to `www` (replacing the CloudFront viewer-request function; the `index.html` rewrite it also did is native Pages behaviour). A gated `cloudflare_registrar_domain` takes over registrar settings once the transfer completes.
- **Terraform, AWS** (`infra/aws/`): adopts the registered domain via `aws_route53domains_registered_domain`, so the nameserver delegation and the transfer unlock are `terraform apply`s (`cloudflare_name_servers`, `domain_transfer_lock`) rather than console steps. Defaults keep today's behaviour until the variables are set.
- **`public/_headers`** (new): the edge security-header layer for Pages — the permissive CSP half incl. `frame-ancestors`, HSTS, Permissions-Policy — mirroring `nginx.conf`; the strict hash-based CSP continues to travel in the built HTML as a `<meta>` policy.
- **CI**: the `deploy-to-aws` job is removed; `deploy-to-cloudflare` remains.
- **Docs**: tech-stack, vision, and architecture no longer describe dual-cloud delivery; the CSP keep-in-sync list names `_headers` instead of the CloudFront Terraform variable. The cutover runbook lives in `infra/cloudflare/README.md`.

## Merge timing

Merging is step 1 of the cutover: both stacks run in Terraform Cloud, so the merge is what applies the new Cloudflare resources. From that moment the AWS deploy job is gone and the CloudFront copy stops receiving content, so proceed to the DNS delegation (runbook step 2 in `infra/cloudflare/README.md`) promptly after merging.

## Verification

- Full preflight gate green (type, lint, format, specs, DESIGN lint, tokens, build, third-party); `dist/_headers` confirmed in the build output.
- `terraform fmt -check` and `terraform validate` pass for both stacks (run in the devcontainer; note the pipeline's Terraform steps don't currently validate `infra/` — the per-step `cd` doesn't persist, a pre-existing issue left for a follow-up).
- No visual-regression run: no rendered output changes.

## Out of scope

The eventual `infra/aws` destroy, deletion of the AWS secrets and `Production` environment, and the registrar transfer itself (auth code + payment — the one step no provider performs).
