### PR TITLE
Repair the Cloudflare edge CSP and document the bulk redirect split

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -35,7 +35,24 @@ export default defineConfig({
                 "manifest-src 'none'",
                 "frame-src 'none'",
                 "child-src 'none'"
-            ]
+            ],
+            // The site's one third-party script: the Cloudflare Web Analytics beacon, injected at
+            // the edge by `auto_install` on cloudflare_web_analytics_site. It never appears in
+            // `dist/`, so `npm run thirdparty:check` cannot see it -- this list is the only place
+            // the dependency is visible.
+            //
+            // `resources` REPLACES Astro's defaults rather than extending them, so 'self' must be
+            // repeated here or every bundled script stops loading. The generated hashes are still
+            // appended.
+            //
+            // Host only, no path: the beacon is served from a versioned URL
+            // (`/beacon.min.js/v<id>`), and a CSP source whose path does not end in `/` must match
+            // exactly, so naming the file would block it. No `connect-src` entry is needed --
+            // because the beacon is auto-installed it reports to the same-origin `/cdn-cgi/rum`,
+            // which `connect-src 'self'` above already covers.
+            scriptDirective: {
+                resources: ["'self'", 'https://static.cloudflareinsights.com']
+            }
         }
     },
     compressHTML: true,
@@ -176,7 +193,7 @@ export default defineConfig({
             // Mirrors the edge header in nginx.conf so `astro preview` (and the Playwright suite,
             // which runs against it) exercises the same two-layer policy as production. Keep the
             // two in sync; the strict, hash-based half is the <meta> policy from `security.csp`.
-            'Content-Security-Policy': `default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';`,
+            'Content-Security-Policy': `default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';`,
             'Permissions-Policy': `accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()`,
             'Referrer-Policy': `same-origin`,
             'Strict-Transport-Security': `max-age=63072000; includeSubDomains; preload`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,12 +143,20 @@ each one.
    and styles and **no `unsafe-inline`**, so an injected inline script does not run. Because the
    hashes are per-page and follow the content, only the build can produce this layer — and
    because it lives in the HTML, it travels unchanged to any host.
-2. **An edge header**, defined in three places that must stay identical: the Terraform variable
-   `content_security_policy` (AWS CloudFront — production), `nginx.conf` (Kubernetes), and
-   `server.headers` in `astro.config.ts` (what `astro preview`, and therefore the Playwright
-   suite, serves). This layer carries what a `<meta>` element cannot express —
-   `frame-ancestors` — and additionally covers non-HTML responses and host-generated error
-   pages, starting from the first byte rather than from the meta tag.
+2. **An edge header**, defined in four places that must stay byte-identical: the
+   `Content-Security-Policy` header in `infra/cloudflare/modules/domain/main.tf` (Cloudflare —
+   production), the Terraform variable `content_security_policy` (AWS CloudFront — the previous
+   host, kept for reference), `nginx.conf` (Kubernetes), and `server.headers` in
+   `astro.config.ts` (what `astro preview`, and therefore the Playwright suite, serves). This
+   layer carries what a `<meta>` element cannot express — `frame-ancestors` — and additionally
+   covers non-HTML responses and host-generated error pages, starting from the first byte rather
+   than from the meta tag.
+
+    A fourth copy is a fourth chance to drift, and the drift is quiet: the site keeps rendering
+    because the inline CSS survives, while fonts and every bundled script fail. When the
+    Cloudflare stack was first stood up it carried a single-layer policy copied from another
+    site, which intersected with the `<meta>` layer to block `font-src` outright and admit no
+    script at all. Check all four when changing any.
 
 The header keeps `'unsafe-inline'` on `script-src`/`style-src` **deliberately**: a static header
 cannot carry per-page hashes, so without it this layer would block the very inline scripts the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,3 +178,25 @@ Two consequences worth knowing:
 
 Astro's CSP does not work in `dev` (the Vite dev server injects its own inline assets) — verify
 with `npm run build` and `npm run serve`.
+
+### The one third-party script
+
+`script-src` names exactly one external host, `https://static.cloudflareinsights.com`, in **both**
+layers: the Cloudflare Web Analytics beacon, injected at the edge by `auto_install` on
+`cloudflare_web_analytics_site`. Three things about it are easy to get wrong:
+
+- **`npm run thirdparty:check` cannot see it.** The guardrail scans `dist/`, and the beacon is
+  added by the edge after the build, so `scriptDirective.resources` in `astro.config.ts` is the
+  only place this dependency is written down. Nothing fails if it is removed — analytics just
+  goes quiet.
+- **The host is named without a path.** The beacon is served from a versioned URL,
+  `/beacon.min.js/v<id>`. A CSP source whose path does not end in `/` must match exactly, so
+  naming the file would block every version of it.
+- **`connect-src` needs nothing.** Because the beacon is auto-installed rather than embedded, it
+  reports to the same-origin `/cdn-cgi/rum`, which `connect-src 'self'` already covers. A
+  manually embedded beacon would post to `cloudflareinsights.com` instead and would need that
+  host added.
+
+Astro's `scriptDirective.resources` **replaces** its default sources rather than extending them,
+so `'self'` is repeated in that list. Dropping it there would block every bundled script on the
+site while leaving the beacon working — a confusing failure worth recognizing.

--- a/infra/aws/modules/simple-static-website/cloudfront-website/variables.tf
+++ b/infra/aws/modules/simple-static-website/cloudfront-website/variables.tf
@@ -35,7 +35,7 @@ variable "aws_cloudfront_function_viewer_request_arn" {
 # already vetted. The <meta> policy is the strict one.
 variable "content_security_policy" {
   type     = string
-  default  = "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  default  = "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   nullable = false
 }
 

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -11,9 +11,9 @@ zone. Zone-level rulesets — the apex→www redirect, the response headers, the
 rule — are invisible to it. Anything that has to act on the Pages hostname must be
 **account-level**.
 
-That is why the pages.dev→www redirect is a Bulk Redirect (`cloudflare_list` +
-`cloudflare_list_item` + an account-level `cloudflare_ruleset`) rather than another
-entry in the zone's redirect ruleset.
+That is why the pages.dev→www redirect is a Bulk Redirect — a `cloudflare_list` and a
+`cloudflare_list_item` here, plus a hand-made Bulk Redirect Rule in the account entry
+point (see below) — rather than another entry in the zone's redirect ruleset.
 
 `include_subdomains = true` on the list item is load-bearing: every
 `wrangler pages deploy` mints a `<hash>.brokenrobot-xyz.pages.dev` URL, so closing only
@@ -44,6 +44,22 @@ So the two halves are split by who can own them:
 Lists are not singletons, so each site keeps its own in Terraform. Only the Rules are
 manual, and only because they share the ruleset.
 
+The split follows the provider's own resource inventory. As of v5.22.0:
+
+| Concept            | Resources                                        | Splittable?                                         |
+| ------------------ | ------------------------------------------------ | --------------------------------------------------- |
+| Bulk Redirect List | `cloudflare_list` **and** `cloudflare_list_item` | Yes — one item is one resource, and the API appends |
+| Bulk Redirect Rule | `cloudflare_ruleset` only                        | No — there is no `cloudflare_ruleset_rule`          |
+
+A Rule is not an addressable object. It is an element inside the entry point ruleset's
+`rules` array, and the only handle on that array is the whole ruleset. That is the
+entire reason the two halves are owned differently — not a preference.
+
+The alternative was considered and rejected: one stack could own the ruleset and declare
+**every** site's rule. That works, but it puts each site's redirect in another site's
+repository, and every new site becomes a pull request against that repo. Two dashboard
+clicks per site, once, is the cheaper trade.
+
 Consequences:
 
 - **A new site needs one manual step.** Terraform creates its List; you then add a
@@ -59,6 +75,28 @@ Consequences:
     curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
       "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rulesets/phases/http_request_redirect/entrypoint"
     ```
+
+    `10003 could not find entrypoint ruleset` means no ruleset exists. Anything else,
+    including an empty `rules` array, means one does.
+
+### Adding the Rule for a site
+
+After the site's apply has created its List: dashboard → account home → **Bulk
+Redirects** → Create Bulk Redirect Rule.
+
+- **Name** — `<apex domain> — pages.dev to custom domain`. Rules from every site share
+  one flat table, so the domain leads.
+- **List** — the site's `<apex_domain>_pages_dev_redirect`.
+
+A Rule cannot be created empty; referencing a List is the only thing it does. Creating
+the first Rule is also what brings the entry point ruleset back into existence.
+
+Then confirm `include_subdomains` is doing its job, which is the one item flag nothing
+else exercises:
+
+```
+curl -sI https://<hash>.<project>.pages.dev/ | grep -i '^location'
+```
 
 ## Edge caching hides deployments
 

--- a/infra/cloudflare/modules/domain/main.tf
+++ b/infra/cloudflare/modules/domain/main.tf
@@ -108,13 +108,21 @@ resource "cloudflare_ruleset" "security_and_performance_response_headers" {
             operation = "set"
             value     = "same-origin"
           }
-          # script-src covers the Web Analytics beacon; because it is
-          # auto-installed the beacon posts to the same-origin /cdn-cgi/rum,
-          # hence connect-src 'self' rather than the Cloudflare host.
-          # style-src allows the inline styles in index.html and 404.html.
+          # Second of the two CSP layers -- see docs/architecture.md. Astro emits the
+          # strict, hash-based <meta> policy into every page; this header carries what a
+          # <meta> element cannot (frame-ancestors), covers non-HTML responses and error
+          # pages, and applies from the first byte.
+          #
+          # Browsers enforce both, so a resource must satisfy each. That makes this the
+          # permissive half: 'unsafe-inline' on script-src/style-src is deliberate and is
+          # NOT a weakening -- a static header cannot carry per-page hashes, so without it
+          # this layer would block the very inline scripts the <meta> layer already vetted,
+          # starting with the theme-init script that runs before the parser reaches <meta>.
+          #
+          # Keep byte-identical to nginx.conf and server.headers in astro.config.ts.
           "Content-Security-Policy" = {
             operation = "set"
-            value     = "default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; script-src https://static.cloudflareinsights.com; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+            value     = "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
           }
         }
       }

--- a/infra/cloudflare/modules/domain/main.tf
+++ b/infra/cloudflare/modules/domain/main.tf
@@ -122,7 +122,7 @@ resource "cloudflare_ruleset" "security_and_performance_response_headers" {
           # Keep byte-identical to nginx.conf and server.headers in astro.config.ts.
           "Content-Security-Policy" = {
             operation = "set"
-            value     = "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+            value     = "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
           }
         }
       }

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,7 +40,7 @@ http {
         # 'unsafe-inline' on script-src/style-src is deliberate and is NOT a weakening: a header
         # cannot carry the per-page hashes, so without it this layer would block the very inline
         # scripts and styles the meta policy has already vetted. The meta policy is the strict one.
-        add_header Content-Security-Policy "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; frame-src 'none'; img-src 'self'; manifest-src 'none'; media-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; style-src-attr 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';" always;
         add_header Referrer-Policy "same-origin";
         add_header X-Content-Type-Options "nosniff";
         add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), gamepad=(), geolocation=(), gyroscope=(), fullscreen=(self), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()";


### PR DESCRIPTION
Two independent problems, both introduced when the Cloudflare stack was stood up by copying `infra/cloudflare/` verbatim from another site.

## 1. The edge CSP was a single-layer policy (`7e7f57f`)

This site delivers CSP in **two layers** (`67c7aec`): a strict hash-based `<meta>` policy from `security.csp`, and a permissive edge header that carries what `<meta>` cannot. Browsers enforce both, so a resource must satisfy each.

The copied stack brought a *single*-layer header, which isn't permissive. Intersected with the `<meta>` layer it left:

| Resource | `<meta>` | old header | result |
| --- | --- | --- | --- |
| Theme-init inline script | ✅ hash | ❌ no `'unsafe-inline'` | blocked → theme flash |
| `/_astro/*.js` | ✅ `'self'` | ❌ no `'self'` | blocked → theme toggle dead |
| Fonts | ✅ `font-src 'self'` | ❌ no `font-src` → `default-src 'none'` | blocked |
| Inline styles | ✅ hashes | ✅ `'unsafe-inline'` | passed |

That last row is why this wasn't obvious: `inlineStylesheets: 'always'` means the CSS is inline, so the site kept *looking* right while fonts and every script failed.

Restores the canonical header, byte-verified against all other copies.

## 2. Web Analytics was blocked in both layers (`24d005a`)

The beacon is edge-injected from `static.cloudflareinsights.com`, which neither layer allowed — the `<meta>` layer permits only `'self'` plus hashes. Adds the host to both.

Two details worth a reviewer's eye:

- **Host only, no path.** The beacon is served from `/beacon.min.js/v<id>`, and a CSP source whose path doesn't end in `/` must match exactly - naming the file would block every version.
- **`'self'` is repeated in `scriptDirective.resources`.** That list *replaces* Astro's defaults rather than extending them. Dropping it would block every bundled script while leaving the beacon working.

`connect-src` needed nothing: auto-install posts to same-origin `/cdn-cgi/rum`.

## 3. Bulk Redirect ownership, documented (`42c28d9`)

Follow-up to the `fix:` already merged as `9c72d0b`. Records *why* Rules are manual and Lists are not: the provider ships `cloudflare_list_item` but has no `cloudflare_ruleset_rule`, so a Rule isn't addressable - it's an element of the singleton entry point's `rules` array. Also records the rejected single-owner alternative and the manual procedure.

## Docs

`docs/architecture.md` now says the edge header lives in **four** places (Cloudflare is production, not AWS CloudFront) and explains why that count is a hazard - the drift is quiet. New subsection covers the one third-party script, including that `npm run thirdparty:check` structurally cannot see it: the guardrail scans `dist/`, and the beacon is injected after the build.

## Verification

- Built output: `script-src 'self' https://static.cloudflareinsights.com` + all 9 hashes on all 14 pages.
- All four header copies byte-identical.
- `thirdparty:check`, `type:check`, `lint:check`, `format:check`, `specs:check`, `designmd:check`, `tokens:check` pass; `terraform fmt`/`validate` clean on both stacks.

**After deploy, confirm in the console:** fonts load, theme toggle works, no flash on first paint, no `Refused to load the script` for `beacon.min.js`.

## Not in this PR

- The comment in `scripts/check-third-party-resources.mjs` still says every fetch directive is `'self'` or `'none'` — now imprecise for `script-src`, though its premise holds since the beacon never lands in `dist/`.
